### PR TITLE
hardcode deepdiff to supported py2 version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
     name:
       - f5-sdk
       - bigsuds
-      - deepdiff
+      - deepdiff==3.3.0
 
 - name: install AWS dependencies
   become: true


### PR DESCRIPTION
fix issue carlbuchmann/iac-dev#21